### PR TITLE
[Fixed]余分なファイルを生成しない設定を追加

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,10 @@ module Kingfisher
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.generators do |g|
+      # この二行の記述で自動生成しない設定を作成しています。
+      g.assets false
+      g.helper false
+    end
   end
 end


### PR DESCRIPTION
変更ファイル:config>application.rb

無駄なファイルを生成しないよう、以下のコードを追記

`config.generators do |g|
      # この二行の記述で自動生成しない設定を作成しています。
      g.assets false
      g.helper false
    end`